### PR TITLE
work-around to set namespace for thirdparty resources.

### DIFF
--- a/k8sv1beta1/apis/apisextensionsvbeta_api.py
+++ b/k8sv1beta1/apis/apisextensionsvbeta_api.py
@@ -739,7 +739,7 @@ class ApisextensionsvbetaApi(object):
                                             callback=params.get('callback'))
         return response
 
-    def create_third_party_resource(self, body, **kwargs):
+    def create_third_party_resource(self, body, namespace, **kwargs):
         """
         create a ThirdPartyResource
         
@@ -777,9 +777,14 @@ class ApisextensionsvbetaApi(object):
         # verify the required parameter 'body' is set
         if ('body' not in params) or (params['body'] is None):
             raise ValueError("Missing the required parameter `body` when calling `create_third_party_resource`")
+        # verify the required parameter 'namespace' is set
+        if ('namespace' not in params) or (params['namespace'] is None):
+            raise ValueError("Missing the required parameter `namespace` when calling `create_third_party_resource`")
 
-        resource_path = '/apis/extensions/v1beta1/thirdpartyresources'.replace('{format}', 'json')
+        resource_path = '/apis/extensions/v1beta1/namespaces/{namespace}/thirdpartyresources'.replace('{format}', 'json')
         path_params = {}
+        if 'namespace' in params:
+            path_params['namespace'] = params['namespace']
 
         query_params = {}
         if 'pretty' in params:


### PR DESCRIPTION
Kubernetes 1.2.2 thirdpartyresources API expects **namespaced** resources, though the docs say this should be non-namespaced. This work-around allows us to set a namespace for thirdparty resources. This is a temporary solution as this should be fixed in kubernetes 1.3.